### PR TITLE
Tweaks to console commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "chen"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.6"
+ThisBuild / version      := "2.0.7"
 ThisBuild / scalaVersion := "3.3.1"
 
 val cpgVersion = "1.0.0"

--- a/chenpy/logger.py
+++ b/chenpy/logger.py
@@ -49,7 +49,6 @@ console = Console(
     log_time=False,
     log_path=False,
     theme=custom_theme,
-    width=int(os.getenv("COLUMNS", "270")),
     color_system="256",
     force_terminal=True,
     highlight=True,

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/chen",
   "issueTracker": "https://github.com/AppThreat/chen/issues",
   "name": "chen",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Code Hierarchy Exploration Net (chen) is an advanced exploration toolkit for your application source code and its dependency hierarchy.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/console/src/main/scala/io/appthreat/console/Console.scala
+++ b/console/src/main/scala/io/appthreat/console/Console.scala
@@ -460,6 +460,30 @@ class Console[T <: Project](
         table.add_row("Imports", "" + atom.imports.size)
         table.add_row("Literals", "" + atom.literal.size)
         table.add_row("Config Files", "" + atom.configFile.size)
+        table.add_row(
+          "Validation tags",
+          "[#5A7C90]" + atom.tag.name("(validation|sanitization).*").name.size + "[/#5A7C90]"
+        )
+        table.add_row(
+          "Unique packages",
+          "[#5A7C90]" + atom.tag.name("pkg.*").name.dedup.size + "[/#5A7C90]"
+        )
+        table.add_row(
+          "Framework tags",
+          "[#5A7C90]" + atom.tag.name("framework.*").name.size + "[/#5A7C90]"
+        )
+        table.add_row(
+          "Framework input",
+          "[#5A7C90]" + atom.tag.name("framework-(input|route)").name.size + "[/#5A7C90]"
+        )
+        table.add_row(
+          "Framework output",
+          "[#5A7C90]" + atom.tag.name("framework-output").name.size + "[/#5A7C90]"
+        )
+        table.add_row(
+          "Crypto tags",
+          "[#5A7C90]" + atom.tag.name("crypto.*").name.size + "[/#5A7C90]"
+        )
         val appliedOverlays = Overlays.appliedOverlays(atom)
         if appliedOverlays.nonEmpty then table.add_row("Overlays", "" + appliedOverlays.size)
         richConsole.clear()
@@ -517,7 +541,12 @@ class Console[T <: Project](
                             .filterNot(_.methodFullName == "NULL")
                             .toSet
                             .foreach(c =>
-                                if !addedMethods.contains(c.methodFullName) then
+                                if !addedMethods.contains(
+                                      c.methodFullName
+                                    ) && c.methodFullName != "<unknownFullName>" && !c.methodFullName.startsWith(
+                                      "{ "
+                                    )
+                                then
                                     mtree
                                         .add(
                                           c.methodFullName + (if c.callee(

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.6" %}
+{% set version = "2.0.7" %}
 
 package:
   name: chen

--- a/platform/frontends/x2cpg/src/main/resources/tags-vocab.txt
+++ b/platform/frontends/x2cpg/src/main/resources/tags-vocab.txt
@@ -88,3 +88,5 @@ jndi
 ldif
 jdbm
 kerberos
+oidc
+oauth2

--- a/platform/frontends/x2cpg/src/main/scala/io/appthreat/x2cpg/passes/taggers/CdxPass.scala
+++ b/platform/frontends/x2cpg/src/main/scala/io/appthreat/x2cpg/passes/taggers/CdxPass.scala
@@ -105,8 +105,11 @@ class CdxPass(atom: Cpg) extends CpgPass(atom):
                 properties.foreach { ns =>
                     val nsstr  = ns.hcursor.downField("value").as[String].getOrElse("")
                     val nsname = ns.hcursor.downField("name").as[String].getOrElse("")
-                    // Skip the SrcFile property
-                    if nsname != "SrcFile" then
+                    // Skip the SrcFile, ResolvedUrl, GradleProfileName, cdx: properties
+                    if nsname != "SrcFile" && nsname != "ResolvedUrl" && nsname != "GradleProfileName" && !nsname.startsWith(
+                          "cdx:"
+                        )
+                    then
                         nsstr
                             .split("(\n|,)")
                             .filterNot(_.startsWith("java."))

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,8 +1,6 @@
 /* reads version declarations from /build.sbt so that we can declare them in one place */
 object Versions {
   val cpg = parseVersion("cpgVersion")
-  // Dont upgrade antlr to 4.10 or above since those versions require java 11 or higher which
-  // causes problems upstreams.
   val antlr         = "4.13.1"
   val scalatest     = "3.2.17"
   val cats          = "3.5.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appthreat-chen"
-version = "2.0.6"
+version = "2.0.7"
 description = "Code Hierarchy Exploration Net (chen)"
 authors = ["Team AppThreat <cloud@appthreat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Summary displays counts for some of the automatic tags.

```
Atom Summary        
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃ Node Type        ┃ Count ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│ Files            │ 94    │
│ Methods          │ 1022  │
│ Annotations      │ 0     │
│ Imports          │ 339   │
│ Literals         │ 4810  │
│ Config Files     │ 150   │
│ Validation tags  │ 5     │
│ Unique packages  │ 81    │
│ Framework tags   │ 4188  │
│ Framework input  │ 0     │
│ Framework output │ 76    │
│ Crypto tags      │ 0     │
│ Overlays         │ 5     │
└──────────────────┴───────┘
```
