### PR TITLE
Tag the call nodes directly for python

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "chen"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.0.9"
+ThisBuild / version      := "2.0.10"
 ThisBuild / scalaVersion := "3.4.1"
 
 val cpgVersion = "1.0.0"

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/chen",
   "issueTracker": "https://github.com/AppThreat/chen/issues",
   "name": "chen",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Code Hierarchy Exploration Net (chen) is an advanced exploration toolkit for your application source code and its dependency hierarchy.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.9" %}
+{% set version = "2.0.10" %}
 
 package:
   name: chen

--- a/platform/frontends/x2cpg/src/main/scala/io/appthreat/x2cpg/passes/taggers/CdxPass.scala
+++ b/platform/frontends/x2cpg/src/main/scala/io/appthreat/x2cpg/passes/taggers/CdxPass.scala
@@ -110,15 +110,17 @@ class CdxPass(atom: Cpg) extends CpgPass(atom):
                       pkgName.replace("django_", ""),
                       pkgName.replace("py", "")
                     ).foreach { ns =>
-                        val bpkg = toPyModuleForm(ns)
-                        if bpkg.nonEmpty && !donePkgs.contains(bpkg) then
-                            donePkgs.put(bpkg, true)
-                        atom.call.where(
-                          _.methodFullName(bpkg)
-                        ).argument.newTagNode(compPurl).store()(dstGraph)
-                        atom.identifier.typeFullName(bpkg).newTagNode(
-                          compPurl
-                        ).store()(dstGraph)
+                        Set(toPyModuleForm(ns), s"$ns${Pattern.quote(File.separator)}.*").foreach {
+                            bpkg =>
+                                if bpkg.nonEmpty && !donePkgs.contains(bpkg) then
+                                    donePkgs.put(bpkg, true)
+                                atom.call.where(
+                                  _.methodFullName(bpkg)
+                                ).newTagNode(compPurl).store()(dstGraph)
+                                atom.identifier.typeFullName(bpkg).newTagNode(
+                                  compPurl
+                                ).store()(dstGraph)
+                        }
                     }
                 end if
                 val properties = comp.hcursor.downField("properties").focus.flatMap(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appthreat-chen"
-version = "2.0.9"
+version = "2.0.10"
 description = "Code Hierarchy Exploration Net (chen)"
 authors = ["Team AppThreat <cloud@appthreat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Tags more places where the namespace could have a file separator. Especially packages with sub-modules.