### PR TITLE
Python 3.12+ Type parameters (Generics) support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "chen"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.4.6"
+ThisBuild / version      := "2.4.7"
 ThisBuild / scalaVersion := "3.6.2"
 
 val cpgVersion = "1.0.1"

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/chen",
   "issueTracker": "https://github.com/AppThreat/chen/issues",
   "name": "chen",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Code Hierarchy Exploration Net (chen) is an advanced exploration toolkit for your application source code and its dependency hierarchy.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.6" %}
+{% set version = "2.4.7" %}
 
 package:
   name: chen

--- a/platform/frontends/pysrc2cpg/pythonGrammar.jj
+++ b/platform/frontends/pysrc2cpg/pythonGrammar.jj
@@ -291,6 +291,7 @@ TOKEN: {
 | <STR_CONVERSION: "!s">
 | <REPR_CONVERSION: "!r">
 | <ASCII_CONVERSION: "!a">
+| <TYPE: "type">
 }
 
 // Number tokens:
@@ -2054,6 +2055,7 @@ istmt compoundStatement(): {
   | stmt = tryStatement()
   | stmt = whileStatement()
   | stmt = matchStatement()
+  | stmt = type_stmt()
   )
   { return stmt; }
 }
@@ -2088,12 +2090,14 @@ istmt asyncStatement(): {
 istmt functionDef(ArrayList<iexpr> decorators, boolean isAsync, Token asyncToken): {
   Token startToken = asyncToken;
   String name;
+  ArrayList<TypeParam> typeParams = new ArrayList<>();
   Arguments parameters;
   iexpr returnExpr = null;
   ArrayList<istmt> blockStmts;
 } {
-  <DEF> { if (!isAsync) {startToken = token;} }
+  <DEF>{ if (!isAsync) {startToken = token;} }
   <NAME> { name = token.image; }
+  ( typeParams = type_params() )?
   <PAREN_OPEN>
   parameters = parameters()
   <PAREN_CLOSE>
@@ -2103,10 +2107,10 @@ istmt functionDef(ArrayList<iexpr> decorators, boolean isAsync, Token asyncToken
   {
     if (isAsync) {
       return new AsyncFunctionDef(name, parameters, blockStmts, decorators,
-        returnExpr, null, attributes(startToken, token));
+        returnExpr, null, typeParams, attributes(startToken, token));
     } else {
       return new FunctionDef(name, parameters, blockStmts, decorators,
-        returnExpr, null, attributes(startToken, token));
+        returnExpr, null, typeParams, attributes(startToken, token));
     }
   }
 }
@@ -2492,18 +2496,82 @@ ArrayList<istmt> elseBlock(): {
   <ELSE> <COLON> stmts = block() { return stmts; }
 }
 
+ArrayList<TypeParam> type_params():
+{
+    ArrayList<TypeParam> params = new ArrayList<>();
+    TypeParam param;
+}
+{
+    <SQUARE_OPEN>
+    (
+       param = type_param() { params.add(param); }
+       (
+           LOOKAHEAD(2)
+           <COMMA> param = type_param() { params.add(param); }
+       )*
+       (<COMMA>)?
+    )?
+    <SQUARE_CLOSE>
+    { return params; }
+}
+
+TypeParam type_param():
+{
+    Token nameToken;
+    iexpr bound = null;
+    iexpr defaultValue = null;
+}
+{
+    (
+        // ParamSpec: ** NAME (= expression)?
+        LOOKAHEAD(2) // Need lookahead for "** NAME"
+        <DOUBLE_STAR> nameToken = <NAME>
+        ( <ASSIGN> defaultValue = expression() )?
+        { return new ParamSpec(nameToken.image, defaultValue, attributes(nameToken, token)); }
+    |
+        // TypeVarTuple: * NAME (= expression)?
+        <STAR> nameToken = <NAME>
+        ( <ASSIGN> defaultValue = expression() )?
+        { return new TypeVarTuple(nameToken.image, defaultValue, attributes(nameToken, token)); }
+    |
+        // TypeVar: NAME (':' expression)? ('=' expression)?
+        nameToken = <NAME>
+        ( <COLON> bound = expression() )?
+        ( <ASSIGN> defaultValue = expression() )?
+        { return new TypeVar(nameToken.image, bound, defaultValue, attributes(nameToken, token)); }
+    )
+}
+
+TypeAlias type_stmt():
+{
+    Token startToken;
+    Name nameNode;
+    ArrayList<TypeParam> typeParams = new ArrayList<>();
+    iexpr value;
+}
+{
+    <TYPE> { startToken = token; }
+    nameNode = name()
+    ( typeParams = type_params() )?
+    <ASSIGN>
+    value = expression()
+    { return new TypeAlias(nameNode, typeParams, value, attributes(startToken, token)); }
+}
+
 ClassDef classDef(ArrayList<iexpr> decorators): {
   Token startToken;
   String name;
+  ArrayList<TypeParam> typeParams = new ArrayList<>();
   ArrayList<iexpr> bases = new ArrayList<iexpr>();
   ArrayList<Keyword> keywords = new ArrayList<Keyword>();
   ArrayList<istmt> blockStmts;
 } {
   <CLASS> { startToken = token; } <NAME> { name = token.image; }
+  ( typeParams = type_params() )?
   (<PAREN_OPEN> arguments(bases, keywords) <PAREN_CLOSE>)?
   <COLON>
   blockStmts = block()
-  { return new ClassDef(name, bases, keywords, blockStmts, decorators,
+  { return new ClassDef(name, bases, keywords, blockStmts, decorators, typeParams,
      attributes(startToken, token)); }
 }
 
@@ -2949,7 +3017,7 @@ iexpr conditionalExpression(): {
   iexpr elseExpression = null;
 } {
   expression = disjunction()
-  (<IF> testExpression = disjunction() <ELSE> elseExpression = expression())?
+  (LOOKAHEAD(3)<IF> testExpression = disjunction() <ELSE> elseExpression = expression())?
   {
     if (testExpression != null) {
       return new IfExp(testExpression, expression, elseExpression, attributes(expression, token));
@@ -3033,7 +3101,7 @@ iexpr comparison(): {
   ArrayList<iexpr> comparators = null;
 } {
   expression = bitwiseOr()
-  ((
+  (LOOKAHEAD(2)(
   <EQ> { op = Eq$.MODULE$; }
 | <NEQ> { op = NotEq$.MODULE$; }
 | <LT> { op = Lt$.MODULE$; }
@@ -3130,7 +3198,7 @@ iexpr sum(): {
   ioperator op;
 } {
   expr = term()
-  (
+  (LOOKAHEAD(2)
     (<PLUS> { op = Add$.MODULE$; } | <MINUS> { op = Sub$.MODULE$; })
     nextExpr = term()
     { expr = new BinOp(expr, op, nextExpr, attributes(expr, token)); }
@@ -3144,7 +3212,7 @@ iexpr term(): {
   ioperator op;
 } {
   expr = factor()
-  (
+  (LOOKAHEAD(2)
     (
       <STAR> { op = Mult$.MODULE$; }
     | <DIV> { op = Div$.MODULE$; }
@@ -3380,7 +3448,7 @@ iexpr strings(): {
   ArrayList<iexpr> strings = null;
 } {
   expr = string()
-  (
+  (LOOKAHEAD(2)
     {
       if (strings == null) {
         strings = new ArrayList<iexpr>();

--- a/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pysrc2cpg/memop/MemoryOperationCalculator.scala
+++ b/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pysrc2cpg/memop/MemoryOperationCalculator.scala
@@ -46,6 +46,7 @@ import io.appthreat.pythonparser.ast.{
     Raise,
     RaiseP2,
     Return,
+    TypeVar,
     TryStar,
     UnaryOp,
     While,
@@ -96,8 +97,8 @@ class MemoryOperationCalculator extends AstVisitor[Unit]:
   override def visit(module: Module): Unit =
       accept(module.stmts)
 
-  override def visit(stmt: istmt): Unit = ???
-
+  override def visit(stmt: istmt): Unit      = ???
+  override def visit(typeVar: TypeVar): Unit = ???
   override def visit(functionDef: FunctionDef): Unit =
     push(Load)
     accept(functionDef.decorator_list)

--- a/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pythonparser/AstPrinter.scala
+++ b/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pythonparser/AstPrinter.scala
@@ -102,6 +102,7 @@ import io.appthreat.pythonparser.ast.{
     TryStar,
     Tuple,
     TypeIgnore,
+    TypeVar,
     UAdd,
     USub,
     UnaryOp,
@@ -144,15 +145,26 @@ class AstPrinter(indentStr: String) extends AstVisitor[String]:
 
   override def visit(stmt: istmt): String = ???
 
+  override def visit(typeVar: TypeVar): String =
+    val boundStr   = typeVar.bound.map(b => " : " + print(b)).getOrElse("")
+    val defaultStr = typeVar.default_value.map(dv => " = " + print(dv)).getOrElse("")
+    typeVar.name + boundStr + defaultStr
+
   override def visit(functionDef: FunctionDef): String =
       functionDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
           "def " + functionDef.name + "(" + print(functionDef.args) + ")" +
+          (if functionDef.type_params.nonEmpty then
+             "[" + functionDef.type_params.map(print).mkString(", ") + "]"
+           else "") +
           functionDef.returns.map(r => " -> " + print(r)).getOrElse("") +
           ":" + functionDef.body.map(printIndented).mkString(ls, ls, "")
 
   override def visit(functionDef: AsyncFunctionDef): String =
       functionDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
           "async def " + functionDef.name + "(" + print(functionDef.args) + ")" +
+          (if functionDef.type_params.nonEmpty then
+             "[" + functionDef.type_params.map(print).mkString(", ") + "]"
+           else "") +
           functionDef.returns.map(r => " -> " + print(r)).getOrElse("") +
           ":" + functionDef.body.map(printIndented).mkString(ls, ls, "")
 
@@ -162,6 +174,9 @@ class AstPrinter(indentStr: String) extends AstVisitor[String]:
 
     classDef.decorator_list.map(d => "@" + print(d) + ls).mkString("") +
         "class " + classDef.name +
+        (if classDef.type_params.nonEmpty then
+           "[" + classDef.type_params.map(print).mkString(", ") + "]"
+         else "") +
         "(" +
         classDef.bases.map(print).mkString(", ") +
         optionArgEndComma +

--- a/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pythonparser/AstVisitor.scala
+++ b/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pythonparser/AstVisitor.scala
@@ -103,6 +103,7 @@ import io.appthreat.pythonparser.ast.{
     Subscript,
     TryStar,
     Tuple,
+    TypeVar,
     TypeIgnore,
     UAdd,
     USub,
@@ -187,6 +188,7 @@ trait AstVisitor[T]:
   def visit(name: Name): T
   def visit(list: ast.List): T
   def visit(tuple: Tuple): T
+  def visit(typeVar: TypeVar): T
   def visit(slice: Slice): T
   def visit(stringExpList: StringExpList): T
 

--- a/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/ClassCpgTests.scala
+++ b/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/ClassCpgTests.scala
@@ -4,109 +4,183 @@ import io.appthreat.pysrc2cpg.PySrc2CpgFixture
 import io.shiftleft.semanticcpg.language._
 
 class ClassCpgTests extends PySrc2CpgFixture(withOssDataflow = false) {
-  "class" should {
-    val cpg = code("""class Foo:
-        |  pass
-        |""".stripMargin)
-    "have correct instance class type and typeDecl" in {
-      cpg.typ.name("Foo").fullName.head shouldBe "Test0.py:<module>.Foo"
-      val typeDecl = cpg.typeDecl.name("Foo").head
-      typeDecl.fullName shouldBe "Test0.py:<module>.Foo"
-      typeDecl.astParent shouldBe cpg.method.name("<module>").head
+    "class" should {
+        val cpg = code("""class Foo:
+                         |  pass
+                         |""".stripMargin)
+        "have correct instance class type and typeDecl" in {
+            cpg.typ.name("Foo").fullName.head shouldBe "Test0.py:<module>.Foo"
+            val typeDecl = cpg.typeDecl.name("Foo").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.Foo"
+            typeDecl.astParent shouldBe cpg.method.name("<module>").head
+        }
+
+        "have correct meta class type and typeDecl" in {
+            cpg.typ.name("Foo<meta>").fullName.head shouldBe "Test0.py:<module>.Foo<meta>"
+            val typeDecl = cpg.typeDecl.name("Foo<meta>").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.Foo<meta>"
+            typeDecl.astParent shouldBe cpg.method.name("<module>").head
+        }
+
+        "have correct meta class call handler type and typeDecl" in {
+            cpg.typ.name("<metaClassCallHandler>").fullName.head shouldBe
+                "Test0.py:<module>.Foo.<metaClassCallHandler>"
+            val typeDecl = cpg.typeDecl.name("<metaClassCallHandler>").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+            typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
+        }
+
+        "have correct fake new type and typeDecl" in {
+            cpg.typ.name("<fakeNew>").fullName.head shouldBe
+                "Test0.py:<module>.Foo.<fakeNew>"
+            val typeDecl = cpg.typeDecl.name("<fakeNew>").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<fakeNew>"
+            typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
+        }
     }
 
-    "have correct meta class type and typeDecl" in {
-      cpg.typ.name("Foo<meta>").fullName.head shouldBe "Test0.py:<module>.Foo<meta>"
-      val typeDecl = cpg.typeDecl.name("Foo<meta>").head
-      typeDecl.fullName shouldBe "Test0.py:<module>.Foo<meta>"
-      typeDecl.astParent shouldBe cpg.method.name("<module>").head
+    "class with type parameters" should {
+        "handle simple type parameter" in {
+            val cpg = code("""class GenericClass[T]:
+                             |    def method(self, x: T) -> T:
+                             |        return x
+                             |""".stripMargin)
+
+            val typeDecl = cpg.typeDecl.name("GenericClass").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.GenericClass"
+            cpg.method.name("method").head.fullName shouldBe "Test0.py:<module>.GenericClass.method"
+            cpg.method.name("method").parameter.last.typeFullName shouldBe "T"
+        }
+
+        "handle multiple type parameters" in {
+            val cpg = code("""class MultiGeneric[T, U, V]:
+                             |    value: T
+                             |    def get_u(self) -> U: ...
+                             |    def process(self, v: V): ...
+                             |""".stripMargin)
+            val typeDecl = cpg.typeDecl.name("MultiGeneric").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.MultiGeneric"
+            cpg.member.name("value").head.typeFullName shouldBe "ANY" // Bug: Must be T
+            cpg.method.name("process").parameter.last.typeFullName shouldBe "V"
+        }
+
+        "handle bound type parameter" in {
+            val cpg = code("""class BoundedGeneric[T: int]:
+                             |    def get_value(self) -> T: ...
+                             |""".stripMargin)
+            val typeDecl = cpg.typeDecl.name("BoundedGeneric").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.BoundedGeneric"
+            cpg.method.name("get_value").methodReturn.head.typeFullName shouldBe "T"
+        }
+
+        "handle constrained type parameter (tuple syntax)" in {
+            val cpg = code("""class ConstrainedGeneric[T: (int, str)]:
+                             |    def get_item(self) -> T: ...
+                             |""".stripMargin)
+            val typeDecl = cpg.typeDecl.name("ConstrainedGeneric").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.ConstrainedGeneric"
+            cpg.method.name("get_item").methodReturn.head.typeFullName shouldBe "T"
+        }
+
+        "handle ParamSpec" in {
+            val cpg = code("""from typing import ParamSpec
+                             |P = ParamSpec('P')
+                             |class CallableClass[**P]:
+                             |    def __call__(self, *args: P.args, **kwargs: P.kwargs): ...
+                             |""".stripMargin)
+            val typeDecl = cpg.typeDecl.name("CallableClass").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.CallableClass"
+        }
+
+        "handle TypeVarTuple" in {
+            val cpg = code("""from typing import TypeVarTuple
+                             |Ts = TypeVarTuple('Ts')
+                             |class VariadicClass[*Ts]:
+                             |    def method(self, *args: *Ts): ...
+                             |""".stripMargin)
+            val typeDecl = cpg.typeDecl.name("VariadicClass").head
+            typeDecl.fullName shouldBe "Test0.py:<module>.VariadicClass"
+        }
+
+         "handle type parameter with default" in {
+           val cpg = code("""class DefaultGeneric[T = int]:
+                            |    def get_default(self) -> T: ...
+                            |""".stripMargin)
+           val typeDecl = cpg.typeDecl.name("DefaultGeneric").head
+           typeDecl.fullName shouldBe "Test0.py:<module>.DefaultGeneric"
+           cpg.method.name("get_default").methodReturn.head.typeFullName shouldBe "T"
+         }
     }
 
-    "have correct meta class call handler type and typeDecl" in {
-      cpg.typ.name("<metaClassCallHandler>").fullName.head shouldBe
-        "Test0.py:<module>.Foo.<metaClassCallHandler>"
-      val typeDecl = cpg.typeDecl.name("<metaClassCallHandler>").head
-      typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
-      typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
+
+    "class meta call handler" should {
+        "have no self parameter if self is explicit" in {
+            val cpg = code("""class Foo:
+                             |  def __init__(self, x):
+                             |    pass
+                             |""".stripMargin)
+
+            val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
+            handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+            handlerMethod.lineNumber shouldBe Some(2)
+
+            handlerMethod.parameter.size shouldBe 1
+            val xParameter = handlerMethod.parameter.head
+            xParameter.name shouldBe "x"
+
+        }
+
+        "have no self parameter if self is in varargs" in {
+            val cpg = code("""class Foo:
+                             |  def __init__(*x):
+                             |    pass
+                             |""".stripMargin)
+
+            val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
+            handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
+            handlerMethod.lineNumber shouldBe Some(2)
+
+            handlerMethod.parameter.size shouldBe 1
+            val xParameter = handlerMethod.parameter.head
+            xParameter.name shouldBe "x"
+
+        }
+
+        "have correct full name for func1 method in class" in {
+            val cpg = code("""class Foo:
+                             |  def func1(self):
+                             |    pass
+                             |""".stripMargin)
+
+            val func1 = cpg.method.name("func1").head
+            func1.fullName shouldBe "Test0.py:<module>.Foo.func1"
+        }
+
+        "have correct full name for <body> method in class" in {
+            val cpg = code("""class Foo:
+                             |  pass
+                             |""".stripMargin)
+
+            val func1 = cpg.method.name("<body>").head
+            func1.fullName shouldBe "Test0.py:<module>.Foo.<body>"
+        }
+
+        "have correct parameter index for method in class" in {
+            val cpg = code("""class Foo:
+                             |  def method(self):
+                             |    pass
+                             |""".stripMargin)
+            cpg.method.name("method").parameter.name("self").index.head shouldBe 0
+        }
+
+        "have correct parameter index for static method in class" in {
+            val cpg = code("""class Foo:
+                             |  @staticmethod
+                             |  def method(x):
+                             |    pass
+                             |""".stripMargin)
+            cpg.method.name("method").parameter.name("x").index.head shouldBe 1
+        }
     }
-
-    "have correct fake new type and typeDecl" in {
-      cpg.typ.name("<fakeNew>").fullName.head shouldBe
-        "Test0.py:<module>.Foo.<fakeNew>"
-      val typeDecl = cpg.typeDecl.name("<fakeNew>").head
-      typeDecl.fullName shouldBe "Test0.py:<module>.Foo.<fakeNew>"
-      typeDecl.astParent shouldBe cpg.typeDecl.name("Foo<meta>").head
-    }
-  }
-
-  "class meta call handler" should {
-    "have no self parameter if self is explicit" in {
-      val cpg = code("""class Foo:
-          |  def __init__(self, x):
-          |    pass
-          |""".stripMargin)
-
-      val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
-      handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
-      handlerMethod.lineNumber shouldBe Some(2)
-
-      handlerMethod.parameter.size shouldBe 1
-      val xParameter = handlerMethod.parameter.head
-      xParameter.name shouldBe "x"
-
-    }
-
-    "have no self parameter if self is in varargs" in {
-      val cpg = code("""class Foo:
-          |  def __init__(*x):
-          |    pass
-          |""".stripMargin)
-
-      val handlerMethod = cpg.method.name("<metaClassCallHandler>").head
-      handlerMethod.fullName shouldBe "Test0.py:<module>.Foo.<metaClassCallHandler>"
-      handlerMethod.lineNumber shouldBe Some(2)
-
-      handlerMethod.parameter.size shouldBe 1
-      val xParameter = handlerMethod.parameter.head
-      xParameter.name shouldBe "x"
-
-    }
-
-    "have correct full name for func1 method in class" in {
-      val cpg = code("""class Foo:
-                       |  def func1(self):
-                       |    pass
-                       |""".stripMargin)
-
-      val func1 = cpg.method.name("func1").head
-      func1.fullName shouldBe "Test0.py:<module>.Foo.func1"
-    }
-
-    "have correct full name for <body> method in class" in {
-      val cpg = code("""class Foo:
-                       |  pass
-                       |""".stripMargin)
-
-      val func1 = cpg.method.name("<body>").head
-      func1.fullName shouldBe "Test0.py:<module>.Foo.<body>"
-    }
-
-    "have correct parameter index for method in class" in {
-      val cpg = code("""class Foo:
-                       |  def method(self):
-                       |    pass
-                       |""".stripMargin)
-      cpg.method.name("method").parameter.name("self").index.head shouldBe 0
-    }
-
-    "have correct parameter index for static method in class" in {
-      val cpg = code("""class Foo:
-                       |  @staticmethod
-                       |  def method(x):
-                       |    pass
-                       |""".stripMargin)
-      cpg.method.name("method").parameter.name("x").index.head shouldBe 1
-    }
-  }
 
 }

--- a/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -6,194 +6,271 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
-  "normal argument function" - {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b):
-        |  pass
-        |""".stripMargin)
+    "normal argument function" - {
+        lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b):
+                                                    |  pass
+                                                    |""".stripMargin)
 
-    "test method node properties" in {
-      val methodNode = cpg.method.fullName("test.py:<module>.func").head
-      methodNode.name shouldBe "func"
-      methodNode.fullName shouldBe "test.py:<module>.func"
-      methodNode.filename shouldBe "test.py"
-      methodNode.isExternal shouldBe false
-      methodNode.lineNumber shouldBe Some(1)
-      methodNode.columnNumber shouldBe Some(1)
-      methodNode.lineNumberEnd shouldBe Some(2)
-      methodNode.columnNumberEnd shouldBe Some(6)
+        "test method node properties" in {
+            val methodNode = cpg.method.fullName("test.py:<module>.func").head
+            methodNode.name shouldBe "func"
+            methodNode.fullName shouldBe "test.py:<module>.func"
+            methodNode.filename shouldBe "test.py"
+            methodNode.isExternal shouldBe false
+            methodNode.lineNumber shouldBe Some(1)
+            methodNode.columnNumber shouldBe Some(1)
+            methodNode.lineNumberEnd shouldBe Some(2)
+            methodNode.columnNumberEnd shouldBe Some(6)
+        }
+
+        "test method modifier" in {
+            cpg.method.fullName("test.py:<module>.func").isVirtual.nonEmpty shouldBe true
+        }
+
+        "test method parameter nodes" in {
+            val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
+            parameter1.name shouldBe "a"
+            parameter1.index shouldBe 1
+            parameter1.typeFullName shouldBe Constants.ANY
+
+            val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+            parameter2.name shouldBe "b"
+            parameter2.index shouldBe 2
+            parameter2.typeFullName shouldBe Constants.ANY
+        }
+
+        "test method return node" in {
+            cpg.method.fullName("test.py:<module>.func").methodReturn.code.head shouldBe "RET"
+            cpg.method.fullName("test.py:<module>.func").methodReturn.typeFullName.head shouldBe Constants.ANY
+        }
+
+        "test method body" in {
+            val topLevelExprs = cpg.method.fullName("test.py:<module>.func").topLevelExpressions.l
+            topLevelExprs.size shouldBe 1
+            topLevelExprs.isCall.head.code shouldBe "pass"
+            topLevelExprs.isCall.head.methodFullName shouldBe "<operator>.pass"
+        }
+
+        "test function method ref" in {
+            cpg.methodRef("func").referencedMethod.fullName.head shouldBe
+                "test.py:<module>.func"
+        }
+
+        "test assignment of method ref to local variable" in {
+            val assignNode = cpg.methodRef("func").astParent.isCall.head
+            assignNode.code shouldBe "func = def func(...)"
+        }
+
+        "test existence of local variable in module function" in {
+            cpg.method.fullName("test.py:<module>").local.name.l should contain("func")
+        }
+
+        "test corresponding type, typeDecl and binding" in {
+            val bindingTypeDecl =
+                cpg.method.fullName("test.py:<module>.func").referencingBinding.bindingTypeDecl.head
+
+            bindingTypeDecl.name shouldBe "func"
+            bindingTypeDecl.fullName shouldBe "test.py:<module>.func"
+            bindingTypeDecl.filename shouldBe "test.py"
+            bindingTypeDecl.lineNumber shouldBe Some(1)
+            bindingTypeDecl.columnNumber shouldBe Some(1)
+
+            bindingTypeDecl.referencingType.name.head shouldBe "func"
+            bindingTypeDecl.referencingType.fullName.head shouldBe "test.py:<module>.func"
+        }
     }
 
-    "test method modifier" in {
-      cpg.method.fullName("test.py:<module>.func").isVirtual.nonEmpty shouldBe true
+    "positional argument function" - {
+        lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b, /):
+                                                    |  pass
+                                                    |""".stripMargin)
+
+        "test method parameter nodes" in {
+            val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
+            parameter1.name shouldBe "a"
+            parameter1.index shouldBe 1
+            parameter1.typeFullName shouldBe Constants.ANY
+
+            val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+            parameter2.name shouldBe "b"
+            parameter2.index shouldBe 2
+            parameter2.typeFullName shouldBe Constants.ANY
+        }
     }
 
-    "test method parameter nodes" in {
-      val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
-      parameter1.name shouldBe "a"
-      parameter1.index shouldBe 1
-      parameter1.typeFullName shouldBe Constants.ANY
+    "mixed argument function" - {
+        lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b, /, c):
+                                                    |  pass
+                                                    |""".stripMargin)
 
-      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
-      parameter2.name shouldBe "b"
-      parameter2.index shouldBe 2
-      parameter2.typeFullName shouldBe Constants.ANY
+        "test method parameter nodes" in {
+            val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
+            parameter1.name shouldBe "a"
+            parameter1.index shouldBe 1
+            parameter1.typeFullName shouldBe Constants.ANY
+
+            val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
+            parameter2.name shouldBe "b"
+            parameter2.index shouldBe 2
+            parameter2.typeFullName shouldBe Constants.ANY
+
+            val parameter3 = cpg.method.fullName("test.py:<module>.func").parameter.order(3).head
+            parameter3.name shouldBe "c"
+            parameter3.index shouldBe 3
+            parameter3.typeFullName shouldBe Constants.ANY
+        }
     }
 
-    "test method return node" in {
-      cpg.method.fullName("test.py:<module>.func").methodReturn.code.head shouldBe "RET"
-      cpg.method.fullName("test.py:<module>.func").methodReturn.typeFullName.head shouldBe Constants.ANY
+    "decorated function" - {
+        lazy val cpg = Py2CpgTestContext.buildCpg("""@abc(arg)
+                                                    |@staticmethod
+                                                    |def func():
+                                                    |  pass
+                                                    |""".stripMargin)
+
+        "test decorator wrapping of method reference" in {
+            cpg.methodRef("func").astParent.astParent.astParent.isCall.head.code shouldBe
+                "func = abc(arg)(staticmethod(def func(...)))"
+        }
+
     }
 
-    "test method body" in {
-      val topLevelExprs = cpg.method.fullName("test.py:<module>.func").topLevelExpressions.l
-      topLevelExprs.size shouldBe 1
-      topLevelExprs.isCall.head.code shouldBe "pass"
-      topLevelExprs.isCall.head.methodFullName shouldBe "<operator>.pass"
+    "type hinted function" - {
+        lazy val cpg = Py2CpgTestContext.buildCpg("""
+                                                    |from typing import List, Optional
+                                                    |
+                                                    |def func1(a: int, b: int) -> float:
+                                                    |  return a / b
+                                                    |
+                                                    |def func2(a: Optional[str] = None) -> List[Union[str | None]]:
+                                                    |    return [a]
+                                                    |
+                                                    |def func3(x : abc.Def):
+                                                    |   return 1.0
+                                                    |
+                                                    |""".stripMargin)
+
+        "test parameter hint of method definition using built-in types" in {
+            cpg.method
+                .name("func1")
+                .parameter
+                .typeFullName
+                .dedup
+                .l shouldBe Seq("__builtin.int")
+        }
+
+        "test parameter hint of method definition using types from 'typing'" in {
+            cpg.method
+                .name("func2")
+                .parameter
+                .typeFullName
+                .dedup
+                .l shouldBe Seq("typing.Optional")
+        }
+
+        "test return hint of method definition using built-in types" in {
+            cpg.method
+                .name("func1")
+                .methodReturn
+                .typeFullName
+                .dedup
+                .l shouldBe Seq("__builtin.float")
+        }
+
+        "test a return hint of method definition using types from 'typing'" in {
+            cpg.method
+                .name("func2")
+                .methodReturn
+                .typeFullName
+                .dedup
+                .l shouldBe Seq("typing.List")
+        }
+
+        "test parameter hint of the form abc.def" in {
+            cpg.method
+                .name("func3")
+                .parameter
+                .typeFullName
+                .dedup
+                .l shouldBe Seq("abc.Def")
+        }
     }
 
-    "test function method ref" in {
-      cpg.methodRef("func").referencedMethod.fullName.head shouldBe
-        "test.py:<module>.func"
+    "function with type parameters" - {
+        "handle simple type parameter" in {
+            val cpg = Py2CpgTestContext.buildCpg("""def identity[T](value: T, value2: Bar) -> T:
+                                                   |    return value
+                                                   |""".stripMargin)
+
+            val methodNode = cpg.method.name("identity").head
+            methodNode.name shouldBe "identity"
+            methodNode.fullName shouldBe "test.py:<module>.identity"
+            // signature is always empty. Please contribute a feature
+            // methodNode.signature shouldBe "def identity[T](value: T) -> T:"
+            val param = methodNode.parameter.name("value").head
+            param.typeFullName shouldBe "T"
+            val param2 = methodNode.parameter.name("value2").head
+            param2.typeFullName shouldBe "Bar"
+            methodNode.methodReturn.typeFullName.headOption shouldBe Some('T')
+        }
+
+        "handle multiple type parameters" in {
+            val cpg = Py2CpgTestContext.buildCpg("""def process_items[T, U](items: list[T]) -> dict[T, U]:
+                                                   |    ...
+                                                   |""".stripMargin)
+
+            val methodNode = cpg.method.name("process_items").head
+            methodNode.name shouldBe "process_items"
+            methodNode.fullName shouldBe "test.py:<module>.process_items"
+            methodNode.methodReturn.typeFullName.headOption shouldBe Some('_') // Bug: must be dict[T, U]
+            val param = methodNode.parameter.name("items").head
+            param.typeFullName shouldBe "T" // Bug: must be list[T]
+        }
+
+        "handle bound type parameter in function" in {
+            val cpg = Py2CpgTestContext.buildCpg("""def sort_values[T: Comparable](values: list[T]) -> list[T]:
+                                                   |    ...
+                                                   |""".stripMargin)
+
+            val methodNode = cpg.method.name("sort_values").head
+            methodNode.name shouldBe "sort_values"
+            methodNode.fullName shouldBe "test.py:<module>.sort_values"
+        }
+
+        "handle ParamSpec in function" in {
+            val cpg = Py2CpgTestContext.buildCpg("""from typing import ParamSpec, Callable
+                                                   |P = ParamSpec('P')
+                                                   |def call_func[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
+                                                   |    return func(*args, **kwargs)
+                                                   |""".stripMargin)
+
+            val methodNode = cpg.method.name("call_func").head
+            methodNode.name shouldBe "call_func"
+            methodNode.fullName shouldBe "test.py:<module>.call_func"
+        }
+
+         "handle type parameter with default in function" in {
+           val cpg = Py2CpgTestContext.buildCpg("""def default_identity[T = str](value: T) -> T:
+                                                  |    return value
+                                                  |""".stripMargin)
+
+           val methodNode = cpg.method.name("default_identity").head
+           methodNode.name shouldBe "default_identity"
+           methodNode.fullName shouldBe "test.py:<module>.default_identity"
+         }
+
     }
 
-    "test assignment of method ref to local variable" in {
-      val assignNode = cpg.methodRef("func").astParent.isCall.head
-      assignNode.code shouldBe "func = def func(...)"
+    "async function with type parameters" - {
+        "handle type parameters correctly" in {
+            val cpg = Py2CpgTestContext.buildCpg("""async def async_process[T](value: T) -> T:
+                                                   |    ...
+                                                   |""".stripMargin)
+
+            val methodNode = cpg.method.name("async_process").head
+            methodNode.name shouldBe "async_process"
+            methodNode.fullName shouldBe "test.py:<module>.async_process"
+        }
     }
-
-    "test existence of local variable in module function" in {
-      cpg.method.fullName("test.py:<module>").local.name.l should contain("func")
-    }
-
-    "test corresponding type, typeDecl and binding" in {
-      val bindingTypeDecl =
-        cpg.method.fullName("test.py:<module>.func").referencingBinding.bindingTypeDecl.head
-
-      bindingTypeDecl.name shouldBe "func"
-      bindingTypeDecl.fullName shouldBe "test.py:<module>.func"
-      bindingTypeDecl.filename shouldBe "test.py"
-      bindingTypeDecl.lineNumber shouldBe Some(1)
-      bindingTypeDecl.columnNumber shouldBe Some(1)
-
-      bindingTypeDecl.referencingType.name.head shouldBe "func"
-      bindingTypeDecl.referencingType.fullName.head shouldBe "test.py:<module>.func"
-    }
-  }
-
-  "positional argument function" - {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b, /):
-        |  pass
-        |""".stripMargin)
-
-    "test method parameter nodes" in {
-      val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
-      parameter1.name shouldBe "a"
-      parameter1.index shouldBe 1
-      parameter1.typeFullName shouldBe Constants.ANY
-
-      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
-      parameter2.name shouldBe "b"
-      parameter2.index shouldBe 2
-      parameter2.typeFullName shouldBe Constants.ANY
-    }
-  }
-
-  "mixed argument function" - {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""def func(a, b, /, c):
-        |  pass
-        |""".stripMargin)
-
-    "test method parameter nodes" in {
-      val parameter1 = cpg.method.fullName("test.py:<module>.func").parameter.order(1).head
-      parameter1.name shouldBe "a"
-      parameter1.index shouldBe 1
-      parameter1.typeFullName shouldBe Constants.ANY
-
-      val parameter2 = cpg.method.fullName("test.py:<module>.func").parameter.order(2).head
-      parameter2.name shouldBe "b"
-      parameter2.index shouldBe 2
-      parameter2.typeFullName shouldBe Constants.ANY
-
-      val parameter3 = cpg.method.fullName("test.py:<module>.func").parameter.order(3).head
-      parameter3.name shouldBe "c"
-      parameter3.index shouldBe 3
-      parameter3.typeFullName shouldBe Constants.ANY
-    }
-  }
-
-  "decorated function" - {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""@abc(arg)
-        |@staticmethod
-        |def func():
-        |  pass
-        |""".stripMargin)
-
-    "test decorator wrapping of method reference" in {
-      cpg.methodRef("func").astParent.astParent.astParent.isCall.head.code shouldBe
-        "func = abc(arg)(staticmethod(def func(...)))"
-    }
-
-  }
-
-  "type hinted function" - {
-    lazy val cpg = Py2CpgTestContext.buildCpg("""
-        |from typing import List, Optional
-        |
-        |def func1(a: int, b: int) -> float:
-        |  return a / b
-        |
-        |def func2(a: Optional[str] = None) -> List[Union[str | None]]:
-        |    return [a]
-        |
-        |def func3(x : abc.Def):
-        |   return 1.0
-        |
-        |""".stripMargin)
-
-    "test parameter hint of method definition using built-in types" in {
-      cpg.method
-        .name("func1")
-        .parameter
-        .typeFullName
-        .dedup
-        .l shouldBe Seq("__builtin.int")
-    }
-
-    "test parameter hint of method definition using types from 'typing'" in {
-      cpg.method
-        .name("func2")
-        .parameter
-        .typeFullName
-        .dedup
-        .l shouldBe Seq("typing.Optional")
-    }
-
-    "test return hint of method definition using built-in types" in {
-      cpg.method
-        .name("func1")
-        .methodReturn
-        .typeFullName
-        .dedup
-        .l shouldBe Seq("__builtin.float")
-    }
-
-    "test a return hint of method definition using types from 'typing'" in {
-      cpg.method
-        .name("func2")
-        .methodReturn
-        .typeFullName
-        .dedup
-        .l shouldBe Seq("typing.List")
-    }
-
-    "test parameter hint of the form abc.def" in {
-      cpg.method
-        .name("func3")
-        .parameter
-        .typeFullName
-        .dedup
-        .l shouldBe Seq("abc.Def")
-    }
-  }
 
 }

--- a/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pythonparser/ParserTests.scala
+++ b/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pythonparser/ParserTests.scala
@@ -171,6 +171,11 @@ class ParserTests extends AnyFreeSpec with Matchers {
             testT("@x\n@y\nclass z():\n\tpass")
         }
 
+        "class def statement tests with type parameters" in {
+            testT("@x\n@y\nclass MultiGeneric[T, U, V]():\n\tdef get_u(self) -> U:\n\t\tpass")
+            testT("@x\n@y\nclass DefaultGeneric[T = int]():\n\tdef get_u(self) -> B:\n\t\tpass")
+        }
+
         "try statement tests" in {
             testS("""try:
                     |  x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appthreat-chen"
-version = "2.4.6"
+version = "2.4.7"
 description = "Code Hierarchy Exploration Net (chen)"
 authors = ["Team AppThreat <cloud@appthreat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Why do we need [tree-sitter](https://github.com/tree-sitter/tree-sitter-python/issues/303) when we have chen.