### PR TITLE
MethodTraversal was crashing when invoked with empty iterator

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install and test
         run: |
           bash ./platform/frontends/php2atom/install.sh
-          npm install -g @appthreat/atom-parsetools
+          npm install -g @appthreat/atom-parsetools@1.0.16
           python3.12 -m pip install --upgrade pip setuptools
           python3.12 -m pip install poetry
           python3.12 -m poetry config virtualenvs.create false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install and test
         run: |
           bash ./platform/frontends/php2atom/install.sh
-          npm install -g @appthreat/atom-parsetools
+          npm install -g @appthreat/atom-parsetools@1.0.16
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install poetry
           python3 -m poetry config virtualenvs.create false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           SCALAPY_PYTHON_LIBRARY: "python3.12"
       - name: Install and test
         run: |
-          npm install @appthreat/atom-parsetools
+          npm install @appthreat/atom-parsetools@1.0.16
           python -m pip install --upgrade pip setuptools wheel
           pip install poetry
           sudo apt install -y graphviz-dev

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ docker run --rm -v /tmp:/tmp -v $HOME:$HOME -v $(pwd):/app:rw -p 8080:8080 -it g
 ## Local Installation
 
 ```shell
-# Install atom and cdxgen
-sudo npm install -g @appthreat/atom @cyclonedx/cdxgen --omit=optional
+# Install atom-parsetools and cdxgen
+sudo npm install -g @appthreat/atom-parsetools@1.0.16 @cyclonedx/cdxgen --omit=optional
 
 # Install chen from pypi
 pip install appthreat-chen

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -121,7 +121,7 @@ RUN set -e; \
     && /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager 'platform-tools' --sdk_root=/opt/android-sdk-linux \
     && /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager 'platforms;android-34' --sdk_root=/opt/android-sdk-linux \
     && /opt/android-sdk-linux/cmdline-tools/latest/bin/sdkmanager 'build-tools;34.0.0' --sdk_root=/opt/android-sdk-linux \
-    && npm install -g @appthreat/atom @cyclonedx/cdxgen --omit=optional \
+    && npm install -g @appthreat/atom-parsetools@1.0.16 @cyclonedx/cdxgen --omit=optional \
     && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php \
     && mv composer.phar /usr/local/bin/composer
 ENV LC_ALL=en_US.UTF-8 \

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -234,7 +234,8 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal:
               )
             )
         }
-        .reduce(plus)
+        .reduceOption(plus)
+        .getOrElse(ExportResult(0, 0, Seq.empty, None))
   end gml
 
   def gml: ExportResult = gml(null)
@@ -261,7 +262,8 @@ class MethodTraversal(val traversal: Iterator[Method]) extends AnyVal:
               )
             )
         }
-        .reduce(plus)
+        .reduceOption(plus)
+        .getOrElse(ExportResult(0, 0, Seq.empty, None))
   end dot
 
   def dot: ExportResult = dot(null)


### PR DESCRIPTION
Also force atom-parsetools at 1.0.16 to retain Ruby 3.4.x version. Fixes https://github.com/AppThreat/atom/issues/232