### PR TITLE
Restore sub-graph export functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "chen"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.5.13"
+ThisBuild / version      := "2.5.14"
 ThisBuild / scalaVersion := "3.6.2"
 
 val cpgVersion = "2.1.3"

--- a/chenpy/client.py
+++ b/chenpy/client.py
@@ -395,7 +395,7 @@ async def graphml_export(connection, filter_str="method"):
             [
                 """
 import overflowdb.formats.ExportResult
-import overflowdb.formats.graphml.GraphMLExporter
+import io.shiftleft.semanticcpg.language.types.structure.SubgraphGraphMLExporter
 import java.nio.file.{Path, Paths}
 
 case class MethodSubGraph(methodName: String, nodes: Set[Node]) {
@@ -427,7 +427,7 @@ def splitByMethod(cpg: Cpg): IterableOnce[MethodSubGraph] = {
                 """
 ({splitByMethod(cpg).iterator
   .map { case subGraph @ MethodSubGraph(methodName, nodes) =>
-    GraphMLExporter.runExport(nodes, subGraph.edges, Paths.get("%(gml_file)s"))
+    SubgraphGraphMLExporter.runExport(nodes, subGraph.edges, Paths.get("%(gml_file)s"))
   }
   .reduce(plus)
 })

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/chen",
   "issueTracker": "https://github.com/AppThreat/chen/issues",
   "name": "chen",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "description": "Code Hierarchy Exploration Net (chen) is an advanced exploration toolkit for your application source code and its dependency hierarchy.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get('VERSION', '2.5.13') %}
+{% set version = os.environ.get('VERSION', '2.5.14') %}
 
 package:
   name: chen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appthreat-chen"
-version = "2.5.13"
+version = "2.5.14"
 description = "Code Hierarchy Exploration Net (chen)"
 authors = ["Team AppThreat <cloud@appthreat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Latest overflowdb2 only supports exporting the whole graph in streaming mode for performance reasons. This brings back the legacy sub-graph export feature. In the future, this could be removed in favour of a whole graph export.

Related: #100