### PR TITLE
Support js custom routers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name                     := "chen"
 ThisBuild / organization := "io.appthreat"
-ThisBuild / version      := "2.5.15"
+ThisBuild / version      := "2.5.16"
 ThisBuild / scalaVersion := "3.6.2"
 
 val cpgVersion = "2.1.4"

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "downloadUrl": "https://github.com/AppThreat/chen",
   "issueTracker": "https://github.com/AppThreat/chen/issues",
   "name": "chen",
-  "version": "2.5.15",
+  "version": "2.5.16",
   "description": "Code Hierarchy Exploration Net (chen) is an advanced exploration toolkit for your application source code and its dependency hierarchy.",
   "applicationCategory": "code-analysis",
   "keywords": [

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get('VERSION', '2.5.15') %}
+{% set version = os.environ.get('VERSION', '2.5.16') %}
 
 package:
   name: chen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appthreat-chen"
-version = "2.5.15"
+version = "2.5.16"
 description = "Code Hierarchy Exploration Net (chen)"
 authors = ["Team AppThreat <cloud@appthreat.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Support for tagging custom js routes.

```
const itemsRouter = new CustomRouter();

itemsRouter.registerRoute('get', "/", [], controllers.Items.getAll);
itemsRouter.registerRoute('post', "/", [middlewares.validateItem], controllers.Items.create);
```

```
const baseRouter: express.Router = express.Router();
baseRouter.use("/items", itemsRouter);
baseRouter.use("/users", usersRouter);
baseRouter.use("/render", renderRouter);
```