### PR TITLE
Update packages

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "io.circe"             %% "circe-generic"     % Versions.circe,
   "io.circe"             %% "circe-parser"      % Versions.circe,
   "org.zeroturnaround"    % "zt-zip"            % Versions.ZeroturnaroundVersion,
-  "com.lihaoyi"          %% "os-lib"            % "0.11.6",
+  "com.lihaoyi"          %% "os-lib"            % Versions.osLib,
   "com.lihaoyi"          %% "pprint"            % "0.9.6",
   "com.lihaoyi"          %% "cask"              % CaskVersion,
   "dev.scalapy"          %% "scalapy-core"      % "0.5.3",

--- a/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
+++ b/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/EagerSourceTypeSolver.scala
@@ -67,6 +67,16 @@ class EagerSourceTypeSolver(
 
   override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] =
       foundTypes.getOrElse(name, SymbolReference.unsolved())
+
+  def tryToSolveTypeInModule(
+    qualifiedModuleName: String,
+    simpleTypeName: String
+  ): SymbolReference[ResolvedReferenceTypeDeclaration] =
+      foundTypes.getOrElse(
+        qualifiedModuleName,
+        foundTypes.getOrElse(simpleTypeName, SymbolReference.unsolved())
+      )
+
 end EagerSourceTypeSolver
 
 object EagerSourceTypeSolver:

--- a/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
+++ b/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/SimpleCombinedTypeSolver.scala
@@ -48,6 +48,12 @@ class SimpleCombinedTypeSolver extends TypeSolver:
                     result
                 }
 
+  def tryToSolveTypeInModule(
+    qualifiedModuleName: String,
+    simpleTypeName: String
+  ): SymbolReference[ResolvedReferenceTypeDeclaration] =
+      tryToSolveType(qualifiedModuleName)
+
   private def findSolvedTypeWithSolvers(
     typeSolvers: mutable.ArrayBuffer[TypeSolver],
     className: String

--- a/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
+++ b/platform/frontends/javasrc2cpg/src/main/scala/io/appthreat/javasrc2cpg/typesolvers/noncaching/JdkJarTypeSolver.scala
@@ -48,6 +48,12 @@ class JdkJarTypeSolver extends TypeSolver:
     else
       SymbolReference.unsolved()
 
+  def tryToSolveTypeInModule(
+    qualifiedModuleName: String,
+    simpleTypeName: String
+  ): SymbolReference[ResolvedReferenceTypeDeclaration] =
+      tryToSolveType(qualifiedModuleName)
+
   private def lookupType(javaParserName: String)
     : SymbolReference[ResolvedReferenceTypeDeclaration] =
     val name = convertJavaParserNameToStandard(javaParserName)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,35 +1,36 @@
 /* reads version declarations from /build.sbt so that we can declare them in one place */
 object Versions {
-  val cpg: String = parseVersion("cpgVersion")
-  val antlr         = "4.13.2"
-  val cfr                    = "0.152"
-  val scalatest     = "3.2.19"
-  val cats          = "3.6.3"
-  val json4s        = "4.0.7"
-  val gradleTooling = "8.10.1"
-  val circe         = "0.14.15"
-  val requests      = "0.9.0"
-  val upickle       = "4.4.2"
-  val scalaReplPP   = "0.1.85"
-  val commonsCompress = "1.27.1"
-  val typeSafeConfig  = "1.4.5"
-  val versionSort     = "1.0.17"
-  val scalaParallel   = "1.2.0"
-  val ZeroturnaroundVersion = "1.17"
+    val cpg: String = parseVersion("cpgVersion")
+    val antlr         = "4.13.2"
+    val cfr                    = "0.152"
+    val scalatest     = "3.2.19"
+    val cats          = "3.6.3"
+    val json4s        = "4.0.7"
+    val gradleTooling = "8.10.1"
+    val circe         = "0.14.15"
+    val requests      = "0.9.0"
+    val upickle       = "4.4.2"
+    val scalaReplPP   = "0.1.85"
+    val commonsCompress = "1.27.1"
+    val typeSafeConfig  = "1.4.5"
+    val versionSort     = "1.0.17"
+    val scalaParallel   = "1.2.0"
+    val ZeroturnaroundVersion = "1.17"
+    val osLib                 = "0.11.7"
 
-  private def parseVersion(key: String): String = {
-    val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r
-    val versions: List[String] = scala.io.Source
-      .fromFile("build.sbt")
-      .getLines
-      .filter(_.contains(s"val $key"))
-      .collect { case versionRegexp(version) => version }
-      .toList
-    assert(
-      versions.size == 1,
-      s"""unable to extract $key from build.sbt, expected exactly one line like `val $key= "0.0.0-SNAPSHOT"`."""
-    )
-    versions.head
-  }
+    private def parseVersion(key: String): String = {
+        val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r
+        val versions: List[String] = scala.io.Source
+            .fromFile("build.sbt")
+            .getLines
+            .filter(_.contains(s"val $key"))
+            .collect { case versionRegexp(version) => version }
+            .toList
+        assert(
+            versions.size == 1,
+            s"""unable to extract $key from build.sbt, expected exactly one line like `val $key= "0.0.0-SNAPSHOT"`."""
+        )
+        versions.head
+    }
 
 }


### PR DESCRIPTION
Prepare for `javaparser-symbol-solver-core` update to 3.28.0. There is currently one test failure in CallTests.scala (possible regression with type solving) preventing the update.