### PR TITLE
feat(pysrc2cpg): emit Python decorators as Annotation CPG nodes

### DIFF
--- a/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pysrc2cpg/PythonAstVisitor.scala
+++ b/platform/frontends/pysrc2cpg/src/main/scala/io/appthreat/pysrc2cpg/PythonAstVisitor.scala
@@ -240,6 +240,8 @@ class PythonAstVisitor(
     )
     functionDefToMethod.put(functionDef, methodNode)
 
+    addDecoratorAnnotations(methodNode, functionDef.decorator_list)
+
     val wrappedMethodRefNode =
         wrapMethodRefWithDecorators(methodRefNode, functionDef.decorator_list)
 
@@ -278,6 +280,53 @@ class PythonAstVisitor(
           )
       )
 
+  /** For each decorator on a function definition, emit a CPG `Annotation` node
+    * and attach it as an AST child of the given method node. This mirrors how
+    * javasrc2cpg surfaces Java method annotations (`@RequestMapping`,
+    * `@GetMapping`, etc.) so downstream consumers can query `Method.annotation`
+    * uniformly across languages.
+    *
+    * The annotation's `code` field carries the full decorator source text
+    * (e.g. `@app.route("/users", methods=["GET"])`), which is what slice
+    * consumers use to recover URL paths and HTTP verbs for OpenAPI generation.
+    *
+    * Note: this is additive — `wrapMethodRefWithDecorators` still produces the
+    * runtime-semantics call lowering. The Annotation nodes added here are pure
+    * static metadata that consumers that don't care about them simply ignore.
+    */
+  private def addDecoratorAnnotations(
+    methodNode: nodes.NewMethod,
+    decoratorList: Iterable[ast.iexpr]
+  ): Unit =
+      decoratorList.foreach { decorator =>
+          val decoratorCode = "@" + nodeToCode.getCode(decorator)
+          val name          = extractDecoratorName(decorator)
+          val pos           = lineAndColOf(decorator)
+          val annotationNode = nodes
+              .NewAnnotation()
+              .code(decoratorCode)
+              .name(name)
+              .fullName(name)
+              .lineNumber(pos.line)
+              .columnNumber(pos.column)
+          diffGraph.addNode(annotationNode)
+          diffGraph.addEdge(methodNode, annotationNode, EdgeTypes.AST)
+      }
+
+  /** Best-effort extraction of a stable short name for a decorator expression,
+    * matching what javasrc2cpg puts in `Annotation.name`.
+    *   - `@auth`                -> "auth"
+    *   - `@app.route(...)`      -> "app.route"
+    *   - `@module.cls.method()` -> "module.cls.method"
+    *   - other dynamic forms   -> "" (the full source remains in `code`)
+    */
+  private def extractDecoratorName(expr: ast.iexpr): String =
+      expr match
+          case n: ast.Name      => n.id
+          case a: ast.Attribute => s"${extractDecoratorName(a.value)}.${a.attr}"
+          case c: ast.Call      => extractDecoratorName(c.func)
+          case _                => ""
+
   def convert(functionDef: ast.AsyncFunctionDef): NewNode =
     val methodIdentifierNode =
         createIdentifierNode(functionDef.name, Store, lineAndColOf(functionDef))
@@ -296,6 +345,8 @@ class PythonAstVisitor(
       lineAndColOf(functionDef)
     )
     functionDefToMethod.put(functionDef, methodNode)
+
+    addDecoratorAnnotations(methodNode, functionDef.decorator_list)
 
     val wrappedMethodRefNode =
         wrapMethodRefWithDecorators(methodRefNode, functionDef.decorator_list)

--- a/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/FunctionDefCpgTests.scala
+++ b/platform/frontends/pysrc2cpg/src/test/scala/io/appthreat/pysrc2cpg/cpg/FunctionDefCpgTests.scala
@@ -273,4 +273,71 @@ class FunctionDefCpgTests extends AnyFreeSpec with Matchers {
         }
     }
 
+    "decorator annotations are surfaced on methods" - {
+        "simple bare decorator -> annotation node attached to method" in {
+            val cpg = Py2CpgTestContext.buildCpg("""@auth_required
+                                                   |def handler():
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            val ann = cpg.method.name("handler").annotation.head
+            ann.code shouldBe "@auth_required"
+            ann.name shouldBe "auth_required"
+        }
+
+        "Flask-style decorator with URL literal preserves the path in `code`" in {
+            val cpg = Py2CpgTestContext.buildCpg("""@app.route("/users/v1", methods=["GET"])
+                                                   |def get_users():
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            val ann = cpg.method.name("get_users").annotation.head
+            ann.code should include("/users/v1")
+            ann.code should include("GET")
+            ann.name shouldBe "app.route"
+        }
+
+        "FastAPI-style decorator with URL literal preserves the path" in {
+            val cpg = Py2CpgTestContext.buildCpg("""@app.get("/items/{id}")
+                                                   |def get_item(id):
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            val ann = cpg.method.name("get_item").annotation.head
+            ann.code should include("/items/{id}")
+            ann.name shouldBe "app.get"
+        }
+
+        "stacked decorators produce one annotation per decorator" in {
+            val cpg = Py2CpgTestContext.buildCpg("""@auth_required
+                                                   |@app.route("/admin")
+                                                   |def admin_panel():
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            val codes = cpg.method.name("admin_panel").annotation.code.l.toSet
+            codes should contain("@auth_required")
+            codes.exists(_.contains("/admin")) shouldBe true
+        }
+
+        "async function decorators are surfaced the same way" in {
+            val cpg = Py2CpgTestContext.buildCpg("""@router.post("/login")
+                                                   |async def login():
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            val ann = cpg.method.name("login").annotation.head
+            ann.code should include("/login")
+            ann.name shouldBe "router.post"
+        }
+
+        "function without decorators has no annotations (regression check)" in {
+            val cpg = Py2CpgTestContext.buildCpg("""def plain():
+                                                   |    pass
+                                                   |""".stripMargin)
+
+            cpg.method.name("plain").annotation.l shouldBe empty
+        }
+    }
+
 }


### PR DESCRIPTION
Mirror javasrc2cpg's annotation pipeline for Python decorators so the
full decorator source text (e.g. @app.route("/users", methods=["GET"]))
is surfaced as an Annotation CPG node attached to the decorated Method.
The existing wrapMethodRefWithDecorators runtime-semantics lowering is
preserved untouched — this addition is pure static metadata.

Why:
- Method.annotation today returns empty for Python methods because the
  Python frontend lowers decorators only to call-wrapper expressions,
  not to Annotation CPG nodes. javasrc2cpg already emits Annotation
  nodes for Java method annotations, which is why downstream consumers
  (e.g. atom + atom-tools) can recover URL paths from Spring code but
  not from Flask/FastAPI/Starlette/aiohttp.
- This change closes that gap with zero schema changes — using the
  existing NewAnnotation type.

What it enables downstream:
- atom's existing m.annotation.map loop in UsageSlicing.scala picks up
  the new nodes automatically (no atom change required).
- atom-tools' existing string-literal regex finds URL paths inside
  Annotation.code automatically (no atom-tools change required).

Implementation:
- New helpers addDecoratorAnnotations() and extractDecoratorName() in
  PythonAstVisitor.scala (~50 LOC).
- Single call-site addition in both convert(FunctionDef) and
  convert(AsyncFunctionDef), right after createMethodAndMethodRef.
- Best-effort name extraction handles ast.Name / ast.Attribute /
  ast.Call recursively (e.g. @app.route(...) -> name="app.route").

Tests:
- 6 new tests in FunctionDefCpgTests.scala covering Flask-style,
  FastAPI-style, async functions, stacked decorators, and the
  no-decorator negative case.
- Full pysrc2cpg suite: 412 tests, 0 failures, 0 regressions.
- Pre-existing "decorator wrapping of method reference" test still
  passes, confirming the runtime lowering is unaffected.

Performance:
- O(decorators-per-function) extra work during CPG construction
  (one NewAnnotation node + one AST edge per decorator). No effect on
  slicing hot path. Test suite run time unchanged.
